### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/library/SimpleAcl/BaseObject.php
+++ b/library/SimpleAcl/BaseObject.php
@@ -8,7 +8,7 @@ use SimpleAcl\Object\RecursiveIterator;
  * Use to keep shared function between Roles and Resources.
  *
  */
-abstract class Object implements IteratorAggregate
+abstract class BaseObject implements IteratorAggregate
 {
     /**
      * Hold the name of object.
@@ -62,7 +62,7 @@ abstract class Object implements IteratorAggregate
      *
      * @param Object $child
      */
-    public function addChild(Object $child)
+    public function addChild(BaseObject $child)
     {
         if ( $this->hasChild($child) ) {
             return;
@@ -79,7 +79,7 @@ abstract class Object implements IteratorAggregate
      */
     public function removeChild($needChild)
     {
-        if ( $needChild instanceof Object ) {
+        if ($needChild instanceof BaseObject ) {
             $needChild = $needChild->getName();
         }
 
@@ -102,7 +102,7 @@ abstract class Object implements IteratorAggregate
      */
     public function hasChild($childName)
     {
-        if ( $childName instanceof Object ) {
+        if ($childName instanceof BaseObject ) {
             $childName = $childName->getName();
         }
 

--- a/library/SimpleAcl/Object/ObjectAggregate.php
+++ b/library/SimpleAcl/Object/ObjectAggregate.php
@@ -1,7 +1,7 @@
 <?php
 namespace SimpleAcl\Object;
 
-use SimpleAcl\Object;
+use SimpleAcl\BaseObject;
 
 /**
  * Implement common function for Role and Resources.
@@ -17,7 +17,7 @@ abstract class ObjectAggregate
     /**
      * @param Object $object
      */
-    protected function addObject(Object $object)
+    protected function addObject(BaseObject $object)
     {
         if ( $this->getObject($object) ) {
             return;
@@ -37,7 +37,7 @@ abstract class ObjectAggregate
      */
     protected function removeObject($objectName)
     {
-        if ( $objectName instanceof Object ) {
+        if ($objectName instanceof BaseObject ) {
             $objectName = $objectName->getName();
         }
 
@@ -77,7 +77,7 @@ abstract class ObjectAggregate
      */
     protected function getObject($objectName)
     {
-        if ( $objectName instanceof Object ) {
+        if ($objectName instanceof BaseObject ) {
             $objectName = $objectName->getName();
         }
 

--- a/library/SimpleAcl/Object/RecursiveIterator.php
+++ b/library/SimpleAcl/Object/RecursiveIterator.php
@@ -2,7 +2,7 @@
 namespace SimpleAcl\Object;
 
 use RecursiveIterator as SplIterator;
-use SimpleAcl\Object;
+use SimpleAcl\BaseObject;
 
 /**
  * Used to iterate by Roles and Resources hierarchy.

--- a/library/SimpleAcl/Resource.php
+++ b/library/SimpleAcl/Resource.php
@@ -4,6 +4,6 @@ namespace SimpleAcl;
 /**
  * Represent Resources in ACL.
  */
-class Resource extends Object
+class Resource extends BaseObject
 {
 }

--- a/library/SimpleAcl/Role.php
+++ b/library/SimpleAcl/Role.php
@@ -1,11 +1,11 @@
 <?php
 namespace SimpleAcl;
 
-use SimpleAcl\Object;
+use SimpleAcl\BaseObject;
 
 /**
  * Represent Roles in ACL.
  */
-class Role extends Object
+class Role extends BaseObject
 {
 }

--- a/tests/SimpleAcl/Object/RecursiveIteratorTest.php
+++ b/tests/SimpleAcl/Object/RecursiveIteratorTest.php
@@ -3,7 +3,7 @@ namespace SimpleAclTest;
 
 use PHPUnit_Framework_TestCase;
 
-use SimpleAcl\Object;
+use SimpleAcl\BaseObject;
 use SimpleAcl\Object\RecursiveIterator;
 use RecursiveIteratorIterator;
 
@@ -16,7 +16,7 @@ class RecursiveIteratorTest extends PHPUnit_Framework_TestCase
      */
     protected function getObject($name)
     {
-        return $this->getMockForAbstractClass('SimpleAcl\Object', array($name));
+        return $this->getMockForAbstractClass('SimpleAcl\BaseObject', array($name));
     }
 
     public function testKey()

--- a/tests/SimpleAcl/ObjectTest.php
+++ b/tests/SimpleAcl/ObjectTest.php
@@ -3,14 +3,14 @@ namespace SimpleAclTest;
 
 use PHPUnit_Framework_TestCase;
 
-use SimpleAcl\Object;
+use SimpleAcl\BaseObject;
 
 class ObjectTest extends PHPUnit_Framework_TestCase
 {
     public function testName()
     {
         /** @var Object $object  */
-        $object = $this->getMockForAbstractClass('SimpleAcl\Object', array('TestName'));
+        $object = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('TestName'));
 
         $this->assertEquals($object->getName(), 'TestName');
         $object->setName('NewName');
@@ -20,9 +20,9 @@ class ObjectTest extends PHPUnit_Framework_TestCase
     public function testAddChild()
     {
         /** @var Object $parent */
-        $parent = $this->getMockForAbstractClass('SimpleAcl\Object', array('Parent'));
+        $parent = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('Parent'));
 
-        $child = $this->getMockForAbstractClass('SimpleAcl\Object', array('Child'));
+        $child = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('Child'));
 
         $parent->addChild($child);
 
@@ -34,9 +34,9 @@ class ObjectTest extends PHPUnit_Framework_TestCase
     public function testRemoveChild()
     {
         /** @var Object $parent */
-        $parent = $this->getMockForAbstractClass('SimpleAcl\Object', array('Parent'));
+        $parent = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('Parent'));
 
-        $child = $this->getMockForAbstractClass('SimpleAcl\Object', array('Child'));
+        $child = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('Child'));
 
         $this->assertFalse($parent->removeChild($child));
 
@@ -55,9 +55,9 @@ class ObjectTest extends PHPUnit_Framework_TestCase
     public function testAddSameChild()
     {
         /** @var Object $parent */
-        $parent = $this->getMockForAbstractClass('SimpleAcl\Object', array('Parent'));
+        $parent = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('Parent'));
 
-        $child = $this->getMockForAbstractClass('SimpleAcl\Object', array('Child'));
+        $child = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('Child'));
 
         $parent->addChild($child);
 
@@ -67,7 +67,7 @@ class ObjectTest extends PHPUnit_Framework_TestCase
         $parent->addChild($child);
         $this->assertEquals(1, count($parent->getChildren()));
 
-        $child2 = $this->getMockForAbstractClass('SimpleAcl\Object', array('Child'));
+        $child2 = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('Child'));
 
         $parent->addChild($child2);
 
@@ -81,12 +81,12 @@ class ObjectTest extends PHPUnit_Framework_TestCase
 
     public function testGetChildren()
     {
-        $parent = $this->getMockForAbstractClass('SimpleAcl\Object', array('TestName'));
+        $parent = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('TestName'));
 
-        $child1 = $this->getMockForAbstractClass('SimpleAcl\Object', array('TestNameChild1'));
+        $child1 = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('TestNameChild1'));
         $parent->addChild($child1);
 
-        $child2 = $this->getMockForAbstractClass('SimpleAcl\Object', array('TestNameChild2'));
+        $child2 = $this->getMockForAbstractClass('SimpleAcl\BaseObject', array('TestNameChild2'));
         $parent->addChild($child2);
 
         $this->assertSame(array($child1, $child2), $parent->getChildren());


### PR DESCRIPTION
Object is now a reserved keyword, this PR renames the `\SimpleAcl\Object` class to `\SimpleAcl\BaseObject`.